### PR TITLE
feat: add check for extra command line args provided with amplify delete

### DIFF
--- a/packages/amplify-cli/src/commands/delete.js
+++ b/packages/amplify-cli/src/commands/delete.js
@@ -1,6 +1,12 @@
 module.exports = {
   name: 'delete',
   run: async context => {
+    if (Array.isArray(context.parameters.array) && context.parameters.array.length > 0) {
+      context.print.error('"delete" command does not expect additional arguments.');
+      context.print.error('Perhaps you meant to use the "remove" command instead of "delete"?');
+      process.exit(1);
+    }
+
     await context.amplify.deleteProject(context);
   },
 };


### PR DESCRIPTION
*Issue #, if available:*
#4115

*Description of changes:*
Since `$ amplify delete` is a sensitive and dangerous command, there should be checks in place to ensure that users truly mean to execute it. `$ amplify delete` may be confused with `$ amplify remove <category>`. If `$ amplify delete` is executed with any additional command line arguments, then an error message should be displayed indicating that the `delete` command does not accept any arguments, and a suggestion should be printed that asks the user if they meant to use the `remove` command instead of `delete`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.